### PR TITLE
Do not allow certain commands to be used in DMs

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.Attributes;
+using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
@@ -41,6 +43,8 @@ public class AboutCommandGroup : CommandGroup {
     ///     A feedback sending result which may or may not have succeeded.
     /// </returns>
     [Command("about")]
+    [DiscordDefaultDMPermission(false)]
+    [RequireContext(ChannelContext.Guild)]
     [Description("Shows Boyfriend's developers")]
     [UsedImplicitly]
     public async Task<Result> SendAboutBotAsync() {

--- a/src/Commands/PingCommandGroup.cs
+++ b/src/Commands/PingCommandGroup.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.Attributes;
+using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
@@ -44,6 +46,8 @@ public class PingCommandGroup : CommandGroup {
     /// </returns>
     [Command("ping", "пинг")]
     [Description("Get bot latency")]
+    [DiscordDefaultDMPermission(false)]
+    [RequireContext(ChannelContext.Guild)]
     [UsedImplicitly]
     public async Task<Result> SendPingAsync() {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out _))

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -6,6 +6,7 @@ using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Commands.Attributes;
+using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
@@ -40,8 +41,9 @@ public class RemindCommandGroup : CommandGroup {
     /// <param name="message">The text of the reminder.</param>
     /// <returns>A feedback sending result which may or may not have succeeded.</returns>
     [Command("remind")]
-    [DiscordDefaultDMPermission(false)]
     [Description("Create a reminder")]
+    [DiscordDefaultDMPermission(false)]
+    [RequireContext(ChannelContext.Guild)]
     [UsedImplicitly]
     public async Task<Result> AddReminderAsync(
         [Description("After what period of time mention the reminder")]


### PR DESCRIPTION
This PR prevents usage of `/about`, `/ping` and `/remind` inside DMs. While it may look like these commands do not require a guild attached to them, the language system depends on having a guild to fetch settings from, so it is not possible to use these commands in DMs.