### PR TITLE
Split error logging events into separate files

### DIFF
--- a/src/Boyfriend.cs
+++ b/src/Boyfriend.cs
@@ -1,4 +1,5 @@
 using Boyfriend.Commands;
+using Boyfriend.Commands.Events;
 using Boyfriend.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -71,7 +72,7 @@ public class Boyfriend {
                         .AddInteractivity()
                         .AddInteractionGroup<InteractionResponders>()
                         // Slash command event handlers
-                        .AddPreparationErrorEvent<ErrorLoggingPreparationErrorEvent>()
+                        .AddPreparationErrorEvent<LoggingPreparationErrorEvent>()
                         .AddPostExecutionEvent<ErrorLoggingPostExecutionEvent>()
                         // Services
                         .AddSingleton<GuildDataService>()

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -5,38 +5,7 @@ using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Services;
 using Remora.Results;
 
-namespace Boyfriend.Commands;
-
-/// <summary>
-///     Handles error logging for slash commands that couldn't be successfully prepared.
-/// </summary>
-[UsedImplicitly]
-public class ErrorLoggingPreparationErrorEvent : IPreparationErrorEvent {
-    private readonly ILogger<ErrorLoggingPreparationErrorEvent> _logger;
-
-    public ErrorLoggingPreparationErrorEvent(ILogger<ErrorLoggingPreparationErrorEvent> logger) {
-        _logger = logger;
-    }
-
-    /// <summary>
-    ///     Logs a warning using the injected <see cref="ILogger" /> if the <paramref name="preparationResult" /> has not
-    ///     succeeded.
-    /// </summary>
-    /// <param name="context">The context of the slash command. Unused.</param>
-    /// <param name="preparationResult">The result whose success is checked.</param>
-    /// <param name="ct">The cancellation token for this operation. Unused.</param>
-    /// <returns>A result which has succeeded.</returns>
-    public Task<Result> PreparationFailed(
-        IOperationContext context, IResult preparationResult, CancellationToken ct = default) {
-        if (!preparationResult.IsSuccess && !preparationResult.Error.IsUserOrEnvironmentError()) {
-            _logger.LogWarning("Error in slash command preparation.\n{ErrorMessage}", preparationResult.Error.Message);
-            if (preparationResult.Error is ExceptionError exerr)
-                _logger.LogError(exerr.Exception, "An exception has been thrown");
-        }
-
-        return Task.FromResult(Result.FromSuccess());
-    }
-}
+namespace Boyfriend.Commands.Events;
 
 /// <summary>
 ///     Handles error logging for slash command groups.

--- a/src/Commands/Events/LoggingPreparationErrorEvent.cs
+++ b/src/Commands/Events/LoggingPreparationErrorEvent.cs
@@ -1,0 +1,39 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Commands.Extensions;
+using Remora.Discord.Commands.Services;
+using Remora.Results;
+
+namespace Boyfriend.Commands.Events;
+
+/// <summary>
+///     Handles error logging for slash commands that couldn't be successfully prepared.
+/// </summary>
+[UsedImplicitly]
+public class LoggingPreparationErrorEvent : IPreparationErrorEvent {
+    private readonly ILogger<LoggingPreparationErrorEvent> _logger;
+
+    public LoggingPreparationErrorEvent(ILogger<LoggingPreparationErrorEvent> logger) {
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Logs a warning using the injected <see cref="ILogger" /> if the <paramref name="preparationResult" /> has not
+    ///     succeeded.
+    /// </summary>
+    /// <param name="context">The context of the slash command. Unused.</param>
+    /// <param name="preparationResult">The result whose success is checked.</param>
+    /// <param name="ct">The cancellation token for this operation. Unused.</param>
+    /// <returns>A result which has succeeded.</returns>
+    public Task<Result> PreparationFailed(
+        IOperationContext context, IResult preparationResult, CancellationToken ct = default) {
+        if (!preparationResult.IsSuccess && !preparationResult.Error.IsUserOrEnvironmentError()) {
+            _logger.LogWarning("Error in slash command preparation.\n{ErrorMessage}", preparationResult.Error.Message);
+            if (preparationResult.Error is ExceptionError exerr)
+                _logger.LogError(exerr.Exception, "An exception has been thrown");
+        }
+
+        return Task.FromResult(Result.FromSuccess());
+    }
+}


### PR DESCRIPTION
This PR splits `LoggingPreparationErrorEvent` and `ErrorLoggingPostExecutionEvent` classes into separate files and puts these files in a separate namespace: `Boyfriend.Commands.Events`. This makes these classes easier to find and distinguish from commands groups.