### PR TITLE
Increase thresholds for size labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,24 @@
+XS:
+  name: size/XS
+  lines: 0
+  color: 3CBF00
+S:
+  name: size/S
+  lines: 20
+  color: 5D9801
+M:
+  name: size/M
+  lines: 100
+  color: 7F7203
+L:
+  name: size/L
+  lines: 200
+  color: A14C05
+XL:
+  name: size/XL
+  lines: 1000
+  color: C32607
+XXL:
+  name: size/XXL
+  lines: 2000
+  color: E50009


### PR DESCRIPTION
This PR adds a `labels.yml` file to configure the `pull-request-size` bot. The new thresholds are:
- 0-9 lines for XS
- 10-49 lines for S
- 50-99 lines for M
- 100-499 lines for L
- 500-999 lines for XL
- \>1000 for XXL

In the file, these thresholds are doubled to accomodate for the fact that both additions and deletions are counted (e.g. editing 10 lines will result in 10 additions and 10 deletions, 20 in total)