### PR TITLE
General fixes

### DIFF
--- a/.github/workflows/resharper.yml
+++ b/.github/workflows/resharper.yml
@@ -31,5 +31,5 @@ jobs:
       uses: muno92/resharper_inspectcode@1.7.1
       with:
         solutionPath: ./Boyfriend.sln
-        ignoreIssueType: InvertIf, ConvertIfStatementToReturnStatement, ConvertIfStatementToSwitchStatement
+        ignoreIssueType: InvertIf, ConvertIfStatementToSwitchStatement
         solutionWideAnalysis: true

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -152,7 +152,9 @@ public class BanCommandGroup : CommandGroup {
                 title, target)
             .WithColour(ColorsList.Green).Build();
 
-        _utility.LogActionAsync(cfg, channelId, title, target, description, user, CancellationToken);
+        var logResult = _utility.LogActionAsync(cfg, channelId, user, title, description, target, CancellationToken);
+        if (!logResult.IsSuccess)
+            return Result.FromError(logResult.Error);
 
         return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
     }
@@ -222,7 +224,7 @@ public class BanCommandGroup : CommandGroup {
 
         var title = string.Format(Messages.UserUnbanned, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
-        var logResult = _utility.LogActionAsync(cfg, channelId, title, target, description, user, CancellationToken);
+        var logResult = _utility.LogActionAsync(cfg, channelId, user, title, description, target, CancellationToken);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Data/Options/LanguageOption.cs
+++ b/src/Data/Options/LanguageOption.cs
@@ -27,9 +27,8 @@ public class LanguageOption : Option<CultureInfo> {
 
     /// <inheritdoc />
     public override Result Set(JsonNode settings, string from) {
-        if (!CultureInfoCache.ContainsKey(from.ToLowerInvariant()))
-            return Result.FromError(new ArgumentInvalidError(nameof(from), Messages.LanguageNotSupported));
-
-        return base.Set(settings, from.ToLowerInvariant());
+        return CultureInfoCache.ContainsKey(from.ToLowerInvariant())
+            ? base.Set(settings, from.ToLowerInvariant())
+            : Result.FromError(new ArgumentInvalidError(nameof(from), Messages.LanguageNotSupported));
     }
 }

--- a/src/Services/UtilityService.cs
+++ b/src/Services/UtilityService.cs
@@ -154,15 +154,15 @@ public class UtilityService : IHostedService {
     /// </summary>
     /// <param name="cfg">The guild configuration.</param>
     /// <param name="channelId">The ID of the channel where the action was executed.</param>
-    /// <param name="title">The title for the embed.</param>
-    /// <param name="avatar">The user whose avatar will be displayed next to the <paramref name="title" /> of the embed.</param>
-    /// <param name="description">The description of the embed.</param>
     /// <param name="user">The user who performed the action.</param>
+    /// <param name="title">The title for the embed.</param>
+    /// <param name="description">The description of the embed.</param>
+    /// <param name="avatar">The user whose avatar will be displayed next to the <paramref name="title" /> of the embed.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns></returns>
     public Result LogActionAsync(
-        JsonNode cfg,  Snowflake         channelId, string title, IUser avatar, string description,
-        IUser    user, CancellationToken ct = default) {
+        JsonNode          cfg, Snowflake channelId, IUser user, string title, string description, IUser avatar,
+        CancellationToken ct = default) {
         var publicChannel = GuildSettings.PublicFeedbackChannel.Get(cfg);
         var privateChannel = GuildSettings.PrivateFeedbackChannel.Get(cfg);
         if (GuildSettings.PublicFeedbackChannel.Get(cfg).EmptyOrEqualTo(channelId)


### PR DESCRIPTION
Depends on #55

These changes are really small and I don't know how to reasonably split them into multiple PRs, but here's the changelog:
- The result of the `UtilityService#LogActionAsync` call in `BanCommandGroup#BanUserAsync` is no longer ignored and it's errors will now prevent feedback from being sent;
- Converted `if` statement to a `return` with ternary in `LanguageOption`;
- Slightly decreased method complexity of `MessageDeletedResponder#RespondAsync` by cleverly using Results;
- Changed the order of parameters for `UtilityService#LogActionAsync` to flow better;
- Removed the exemption for `ConvertIfToReturnStatement` for InspectCode.