### PR TITLE
Do not assign Octol1ttle for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
-    assignees:
-      - "Octol1ttle"
     labels:
       - "type: dependencies"
 
@@ -24,8 +22,5 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
-    # Add assignees
-    assignees:
-      - "Octol1ttle"
     labels:
       - "type: dependencies"


### PR DESCRIPTION
This PR disables automatic assignation of all PRs created by Dependabot to me. There are now more people working on Boyfriend than just me. In fact, this project, in theory, can live without me as there are other members working on it.