### PR TITLE
Force maximum Cognitive Complexity via InspectCode

### DIFF
--- a/.github/workflows/resharper.yml
+++ b/.github/workflows/resharper.yml
@@ -4,12 +4,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [ "*" ]
   pull_request:
     branches: [ "master" ]
   merge_group:
     types: [checks_requested]
-  push:
-    branches: [ "master" ]
 
 jobs:
   inspect-code:

--- a/.github/workflows/resharper.yml
+++ b/.github/workflows/resharper.yml
@@ -32,4 +32,5 @@ jobs:
       with:
         solutionPath: ./Boyfriend.sln
         ignoreIssueType: InvertIf, ConvertIfStatementToSwitchStatement
+        extensions: ReSharperPlugin.CognitiveComplexity
         solutionWideAnalysis: true

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -5,6 +5,7 @@ using Boyfriend.Services;
 using JetBrains.Annotations;
 using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
+using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Commands.Attributes;
 using Remora.Discord.Commands.Conditions;
@@ -47,7 +48,7 @@ public class AboutCommandGroup : CommandGroup {
     [RequireContext(ChannelContext.Guild)]
     [Description("Shows Boyfriend's developers")]
     [UsedImplicitly]
-    public async Task<Result> SendAboutBotAsync() {
+    public async Task<Result> ExecuteAboutAsync() {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))
             return Result.FromError(
                 new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
@@ -59,6 +60,10 @@ public class AboutCommandGroup : CommandGroup {
         var cfg = await _dataService.GetSettings(guildId.Value, CancellationToken);
         Messages.Culture = GuildSettings.Language.Get(cfg);
 
+        return await SendAboutBotAsync(currentUser, CancellationToken);
+    }
+
+    private async Task<Result> SendAboutBotAsync(IUser currentUser, CancellationToken ct = default) {
         var builder = new StringBuilder().AppendLine(Markdown.Bold(Messages.AboutTitleDevelopers));
         foreach (var dev in Developers)
             builder.AppendLine($"@{dev} — {$"AboutDeveloper@{dev}".Localized()}");
@@ -73,6 +78,6 @@ public class AboutCommandGroup : CommandGroup {
             .WithImageUrl("https://cdn.upload.systems/uploads/JFAaX5vr.png")
             .Build();
 
-        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, ct);
     }
 }

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -91,8 +91,7 @@ public class BanCommandGroup : CommandGroup {
         IUser target, string reason, TimeSpan? duration, IGuild guild, Snowflake channelId,
         IUser user,   IUser  currentUser) {
         var data = await _dataService.GetData(guild.ID, CancellationToken);
-        var cfg = data.Settings;
-        Messages.Culture = GuildSettings.Language.Get(cfg);
+        Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
         var existingBanResult = await _guildApi.GetGuildBanAsync(guild.ID, target.ID, CancellationToken);
         if (existingBanResult.IsDefined()) {
@@ -152,7 +151,8 @@ public class BanCommandGroup : CommandGroup {
                 title, target)
             .WithColour(ColorsList.Green).Build();
 
-        var logResult = _utility.LogActionAsync(cfg, channelId, user, title, description, target, CancellationToken);
+        var logResult = _utility.LogActionAsync(
+            data.Settings, channelId, user, title, description, target, CancellationToken);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -66,7 +66,7 @@ public class BanCommandGroup : CommandGroup {
     [RequireBotDiscordPermissions(DiscordPermission.BanMembers)]
     [Description("Ban user")]
     [UsedImplicitly]
-    public async Task<Result> ExecuteBan(
+    public async Task<Result> ExecuteBanAsync(
         [Description("User to ban")]  IUser     target,
         [Description("Ban reason")]   string    reason,
         [Description("Ban duration")] TimeSpan? duration = null) {
@@ -84,25 +84,26 @@ public class BanCommandGroup : CommandGroup {
         if (!guildResult.IsDefined(out var guild))
             return Result.FromError(guildResult);
 
-        return await BanUserAsync(target, reason, duration, guild, channelId.Value, user, currentUser);
-    }
-
-    private async Task<Result> BanUserAsync(
-        IUser target, string reason, TimeSpan? duration, IGuild guild, Snowflake channelId,
-        IUser user,   IUser  currentUser) {
         var data = await _dataService.GetData(guild.ID, CancellationToken);
         Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
-        var existingBanResult = await _guildApi.GetGuildBanAsync(guild.ID, target.ID, CancellationToken);
+        return await BanUserAsync(
+            target, reason, duration, guild, data, channelId.Value, user, currentUser, CancellationToken);
+    }
+
+    private async Task<Result> BanUserAsync(
+        IUser target, string reason,      TimeSpan?         duration, IGuild guild, GuildData data, Snowflake channelId,
+        IUser user,   IUser  currentUser, CancellationToken ct = default) {
+        var existingBanResult = await _guildApi.GetGuildBanAsync(guild.ID, target.ID, ct);
         if (existingBanResult.IsDefined()) {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.UserAlreadyBanned, currentUser)
                 .WithColour(ColorsList.Red).Build();
 
-            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, CancellationToken);
+            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
         var interactionResult
-            = await _utility.CheckInteractionsAsync(guild.ID, user.ID, target.ID, "Ban", CancellationToken);
+            = await _utility.CheckInteractionsAsync(guild.ID, user.ID, target.ID, "Ban", ct);
         if (!interactionResult.IsSuccess)
             return Result.FromError(interactionResult);
 
@@ -110,7 +111,7 @@ public class BanCommandGroup : CommandGroup {
             var errorEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
                 .WithColour(ColorsList.Red).Build();
 
-            return await _feedbackService.SendContextualEmbedResultAsync(errorEmbed, CancellationToken);
+            return await _feedbackService.SendContextualEmbedResultAsync(errorEmbed, ct);
         }
 
         var builder = new StringBuilder().AppendLine(string.Format(Messages.DescriptionActionReason, reason));
@@ -122,7 +123,7 @@ public class BanCommandGroup : CommandGroup {
         var title = string.Format(Messages.UserBanned, target.GetTag());
         var description = builder.ToString();
 
-        var dmChannelResult = await _userApi.CreateDMAsync(target.ID, CancellationToken);
+        var dmChannelResult = await _userApi.CreateDMAsync(target.ID, ct);
         if (dmChannelResult.IsDefined(out var dmChannel)) {
             var dmEmbed = new EmbedBuilder().WithGuildTitle(guild)
                 .WithTitle(Messages.YouWereBanned)
@@ -134,12 +135,12 @@ public class BanCommandGroup : CommandGroup {
 
             if (!dmEmbed.IsDefined(out var dmBuilt))
                 return Result.FromError(dmEmbed);
-            await _channelApi.CreateMessageAsync(dmChannel.ID, embeds: new[] { dmBuilt }, ct: CancellationToken);
+            await _channelApi.CreateMessageAsync(dmChannel.ID, embeds: new[] { dmBuilt }, ct: ct);
         }
 
         var banResult = await _guildApi.CreateGuildBanAsync(
             guild.ID, target.ID, reason: $"({user.GetTag()}) {reason}".EncodeHeader(),
-            ct: CancellationToken);
+            ct: ct);
         if (!banResult.IsSuccess)
             return Result.FromError(banResult.Error);
         var memberData = data.GetMemberData(target.ID);
@@ -152,11 +153,11 @@ public class BanCommandGroup : CommandGroup {
             .WithColour(ColorsList.Green).Build();
 
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, CancellationToken);
+            data.Settings, channelId, user, title, description, target, ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
-        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, ct);
     }
 
     /// <summary>
@@ -171,7 +172,7 @@ public class BanCommandGroup : CommandGroup {
     ///     A feedback sending result which may or may not have succeeded. A successful result does not mean that the user
     ///     was unbanned and vice-versa.
     /// </returns>
-    /// <seealso cref="ExecuteBan" />
+    /// <seealso cref="ExecuteBanAsync" />
     /// <seealso cref="GuildUpdateService.TickGuildAsync"/>
     [Command("unban")]
     [DiscordDefaultMemberPermissions(DiscordPermission.BanMembers)]
@@ -196,25 +197,27 @@ public class BanCommandGroup : CommandGroup {
         if (!userResult.IsDefined(out var user))
             return Result.FromError(userResult);
 
-        return await UnbanUserAsync(target, reason, guildId.Value, channelId.Value, user, currentUser);
+        var data = await _dataService.GetData(guildId.Value, CancellationToken);
+        Messages.Culture = GuildSettings.Language.Get(data.Settings);
+
+        return await UnbanUserAsync(
+            target, reason, guildId.Value, data, channelId.Value, user, currentUser, CancellationToken);
     }
 
     private async Task<Result> UnbanUserAsync(
-        IUser target, string reason, Snowflake guildId, Snowflake channelId, IUser user, IUser currentUser) {
-        var cfg = await _dataService.GetSettings(guildId, CancellationToken);
-        Messages.Culture = GuildSettings.Language.Get(cfg);
-
-        var existingBanResult = await _guildApi.GetGuildBanAsync(guildId, target.ID, CancellationToken);
+        IUser target,      string            reason, Snowflake guildId, GuildData data, Snowflake channelId, IUser user,
+        IUser currentUser, CancellationToken ct = default) {
+        var existingBanResult = await _guildApi.GetGuildBanAsync(guildId, target.ID, ct);
         if (!existingBanResult.IsDefined()) {
             var errorEmbed = new EmbedBuilder().WithSmallTitle(Messages.UserNotBanned, currentUser)
                 .WithColour(ColorsList.Red).Build();
 
-            return await _feedbackService.SendContextualEmbedResultAsync(errorEmbed, CancellationToken);
+            return await _feedbackService.SendContextualEmbedResultAsync(errorEmbed, ct);
         }
 
         var unbanResult = await _guildApi.RemoveGuildBanAsync(
             guildId, target.ID, $"({user.GetTag()}) {reason}".EncodeHeader(),
-            ct: CancellationToken);
+            ct);
         if (!unbanResult.IsSuccess)
             return Result.FromError(unbanResult.Error);
 
@@ -224,10 +227,10 @@ public class BanCommandGroup : CommandGroup {
 
         var title = string.Format(Messages.UserUnbanned, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
-        var logResult = _utility.LogActionAsync(cfg, channelId, user, title, description, target, CancellationToken);
+        var logResult = _utility.LogActionAsync(data.Settings, channelId, user, title, description, target, ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
-        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, ct);
     }
 }

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -7,13 +7,13 @@ using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
-using Remora.Discord.API.Objects;
 using Remora.Discord.Commands.Attributes;
 using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
 using Remora.Discord.Extensions.Formatting;
+using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Boyfriend.Commands;
@@ -23,20 +23,17 @@ namespace Boyfriend.Commands;
 /// </summary>
 [UsedImplicitly]
 public class MuteCommandGroup : CommandGroup {
-    private readonly IDiscordRestChannelAPI _channelApi;
-    private readonly ICommandContext        _context;
-    private readonly GuildDataService       _dataService;
-    private readonly FeedbackService        _feedbackService;
-    private readonly IDiscordRestGuildAPI   _guildApi;
-    private readonly IDiscordRestUserAPI    _userApi;
-    private readonly UtilityService         _utility;
+    private readonly ICommandContext      _context;
+    private readonly GuildDataService     _dataService;
+    private readonly FeedbackService      _feedbackService;
+    private readonly IDiscordRestGuildAPI _guildApi;
+    private readonly IDiscordRestUserAPI  _userApi;
+    private readonly UtilityService       _utility;
 
     public MuteCommandGroup(
-        ICommandContext context,         IDiscordRestChannelAPI channelApi, GuildDataService    dataService,
-        FeedbackService feedbackService, IDiscordRestGuildAPI   guildApi,   IDiscordRestUserAPI userApi,
-        UtilityService  utility) {
+        ICommandContext      context,  GuildDataService    dataService, FeedbackService feedbackService,
+        IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,     UtilityService  utility) {
         _context = context;
-        _channelApi = channelApi;
         _dataService = dataService;
         _feedbackService = feedbackService;
         _guildApi = guildApi;
@@ -57,7 +54,7 @@ public class MuteCommandGroup : CommandGroup {
     ///     A feedback sending result which may or may not have succeeded. A successful result does not mean that the member
     ///     was muted and vice-versa.
     /// </returns>
-    /// <seealso cref="UnmuteUserAsync" />
+    /// <seealso cref="ExecuteUnmute" />
     [Command("mute", "мут")]
     [DiscordDefaultMemberPermissions(DiscordPermission.ModerateMembers)]
     [DiscordDefaultDMPermission(false)]
@@ -66,7 +63,7 @@ public class MuteCommandGroup : CommandGroup {
     [RequireBotDiscordPermissions(DiscordPermission.ModerateMembers)]
     [Description("Mute member")]
     [UsedImplicitly]
-    public async Task<Result> MuteUserAsync(
+    public async Task<Result> ExecuteMute(
         [Description("Member to mute")] IUser    target,
         [Description("Mute reason")]    string   reason,
         [Description("Mute duration")]  TimeSpan duration) {
@@ -79,6 +76,13 @@ public class MuteCommandGroup : CommandGroup {
         if (!currentUserResult.IsDefined(out var currentUser))
             return Result.FromError(currentUserResult);
 
+        var userResult = await _userApi.GetUserAsync(userId.Value, CancellationToken);
+        if (!userResult.IsDefined(out var user))
+            return Result.FromError(userResult);
+
+        var data = await _dataService.GetData(guildId.Value, CancellationToken);
+        Messages.Culture = GuildSettings.Language.Get(data.Settings);
+
         var memberResult = await _guildApi.GetGuildMemberAsync(guildId.Value, target.ID, CancellationToken);
         if (!memberResult.IsSuccess) {
             var embed = new EmbedBuilder().WithSmallTitle(Messages.UserNotFoundShort, currentUser)
@@ -87,71 +91,48 @@ public class MuteCommandGroup : CommandGroup {
             return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
         }
 
+        return await MuteUserAsync(target, reason, duration, guildId.Value, data, channelId.Value, user, currentUser);
+    }
+
+    private async Task<Result> MuteUserAsync(
+        IUser target, string reason, TimeSpan duration, Snowflake guildId, GuildData data, Snowflake channelId,
+        IUser user,   IUser  currentUser) {
         var interactionResult
             = await _utility.CheckInteractionsAsync(
-                guildId.Value, userId.Value, target.ID, "Mute", CancellationToken);
+                guildId, user.ID, target.ID, "Mute", CancellationToken);
         if (!interactionResult.IsSuccess)
             return Result.FromError(interactionResult);
 
-        var data = await _dataService.GetData(guildId.Value, CancellationToken);
-        var cfg = data.Settings;
-        Messages.Culture = GuildSettings.Language.Get(cfg);
-
-        Result<Embed> responseEmbed;
         if (interactionResult.Entity is not null) {
-            responseEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
+            var failedEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
                 .WithColour(ColorsList.Red).Build();
-        } else {
-            var userResult = await _userApi.GetUserAsync(userId.Value, CancellationToken);
-            if (!userResult.IsDefined(out var user))
-                return Result.FromError(userResult);
 
-            var until = DateTimeOffset.UtcNow.Add(duration); // >:)
-            var muteResult = await _guildApi.ModifyGuildMemberAsync(
-                guildId.Value, target.ID, reason: $"({user.GetTag()}) {reason}".EncodeHeader(),
-                communicationDisabledUntil: until, ct: CancellationToken);
-            if (!muteResult.IsSuccess)
-                return Result.FromError(muteResult.Error);
-
-            responseEmbed = new EmbedBuilder().WithSmallTitle(
-                    string.Format(Messages.UserMuted, target.GetTag()), target)
-                .WithColour(ColorsList.Green).Build();
-
-            if ((!GuildSettings.PublicFeedbackChannel.Get(cfg).Empty()
-                 && GuildSettings.PublicFeedbackChannel.Get(cfg) != channelId.Value)
-                || (!GuildSettings.PrivateFeedbackChannel.Get(cfg).Empty()
-                    && GuildSettings.PrivateFeedbackChannel.Get(cfg) != channelId.Value)) {
-                var builder = new StringBuilder().AppendLine(string.Format(Messages.DescriptionActionReason, reason))
-                    .Append(
-                        string.Format(
-                            Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until)));
-
-                var logEmbed = new EmbedBuilder().WithSmallTitle(
-                        string.Format(Messages.UserMuted, target.GetTag()), target)
-                    .WithDescription(builder.ToString())
-                    .WithActionFooter(user)
-                    .WithCurrentTimestamp()
-                    .WithColour(ColorsList.Red)
-                    .Build();
-
-                if (!logEmbed.IsDefined(out var logBuilt))
-                    return Result.FromError(logEmbed);
-
-                var builtArray = new[] { logBuilt };
-                // Not awaiting to reduce response time
-                if (GuildSettings.PublicFeedbackChannel.Get(cfg) != channelId.Value)
-                    _ = _channelApi.CreateMessageAsync(
-                        GuildSettings.PublicFeedbackChannel.Get(cfg), embeds: builtArray,
-                        ct: CancellationToken);
-                if (GuildSettings.PrivateFeedbackChannel.Get(cfg) != GuildSettings.PublicFeedbackChannel.Get(cfg)
-                    && GuildSettings.PrivateFeedbackChannel.Get(cfg) != channelId.Value)
-                    _ = _channelApi.CreateMessageAsync(
-                        GuildSettings.PrivateFeedbackChannel.Get(cfg), embeds: builtArray,
-                        ct: CancellationToken);
-            }
+            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, CancellationToken);
         }
 
-        return await _feedbackService.SendContextualEmbedResultAsync(responseEmbed, CancellationToken);
+        var until = DateTimeOffset.UtcNow.Add(duration); // >:)
+        var muteResult = await _guildApi.ModifyGuildMemberAsync(
+            guildId, target.ID, reason: $"({user.GetTag()}) {reason}".EncodeHeader(),
+            communicationDisabledUntil: until, ct: CancellationToken);
+        if (!muteResult.IsSuccess)
+            return Result.FromError(muteResult.Error);
+
+        var title = string.Format(Messages.UserMuted, target.GetTag());
+        var description = new StringBuilder().AppendLine(string.Format(Messages.DescriptionActionReason, reason))
+            .Append(
+                string.Format(
+                    Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until))).ToString();
+
+        var logResult = _utility.LogActionAsync(
+            data.Settings, channelId, user, title, description, target, CancellationToken);
+        if (!logResult.IsSuccess)
+            return Result.FromError(logResult.Error);
+
+        var embed = new EmbedBuilder().WithSmallTitle(
+                string.Format(Messages.UserMuted, target.GetTag()), target)
+            .WithColour(ColorsList.Green).Build();
+
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
     }
 
     /// <summary>
@@ -166,7 +147,7 @@ public class MuteCommandGroup : CommandGroup {
     ///     A feedback sending result which may or may not have succeeded. A successful result does not mean that the member
     ///     was unmuted and vice-versa.
     /// </returns>
-    /// <seealso cref="MuteUserAsync" />
+    /// <seealso cref="ExecuteMute" />
     /// <seealso cref="GuildUpdateService.TickGuildAsync"/>
     [Command("unmute", "размут")]
     [DiscordDefaultMemberPermissions(DiscordPermission.ModerateMembers)]
@@ -176,7 +157,7 @@ public class MuteCommandGroup : CommandGroup {
     [RequireBotDiscordPermissions(DiscordPermission.ModerateMembers)]
     [Description("Unmute member")]
     [UsedImplicitly]
-    public async Task<Result> UnmuteUserAsync(
+    public async Task<Result> ExecuteUnmute(
         [Description("Member to unmute")] IUser  target,
         [Description("Unmute reason")]    string reason) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
@@ -188,8 +169,13 @@ public class MuteCommandGroup : CommandGroup {
         if (!currentUserResult.IsDefined(out var currentUser))
             return Result.FromError(currentUserResult);
 
-        var cfg = await _dataService.GetSettings(guildId.Value, CancellationToken);
-        Messages.Culture = GuildSettings.Language.Get(cfg);
+        // Needed to get the tag and avatar
+        var userResult = await _userApi.GetUserAsync(userId.Value, CancellationToken);
+        if (!userResult.IsDefined(out var user))
+            return Result.FromError(userResult);
+
+        var data = await _dataService.GetData(guildId.Value, CancellationToken);
+        Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
         var memberResult = await _guildApi.GetGuildMemberAsync(guildId.Value, target.ID, CancellationToken);
         if (!memberResult.IsSuccess) {
@@ -199,56 +185,42 @@ public class MuteCommandGroup : CommandGroup {
             return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
         }
 
+        return await UnmuteUserAsync(target, reason, guildId.Value, data, channelId.Value, user, currentUser);
+    }
+
+    private async Task<Result> UnmuteUserAsync(
+        IUser target, string reason, Snowflake guildId, GuildData data, Snowflake channelId, IUser user,
+        IUser currentUser) {
         var interactionResult
             = await _utility.CheckInteractionsAsync(
-                guildId.Value, userId.Value, target.ID, "Unmute", CancellationToken);
+                guildId, user.ID, target.ID, "Unmute", CancellationToken);
         if (!interactionResult.IsSuccess)
             return Result.FromError(interactionResult);
 
-        // Needed to get the tag and avatar
-        var userResult = await _userApi.GetUserAsync(userId.Value, CancellationToken);
-        if (!userResult.IsDefined(out var user))
-            return Result.FromError(userResult);
+        if (interactionResult.Entity is not null) {
+            var failedEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
+                .WithColour(ColorsList.Red).Build();
+
+            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, CancellationToken);
+        }
 
         var unmuteResult = await _guildApi.ModifyGuildMemberAsync(
-            guildId.Value, target.ID, $"({user.GetTag()}) {reason}".EncodeHeader(),
+            guildId, target.ID, $"({user.GetTag()}) {reason}".EncodeHeader(),
             communicationDisabledUntil: null, ct: CancellationToken);
         if (!unmuteResult.IsSuccess)
             return Result.FromError(unmuteResult.Error);
 
-        var responseEmbed = new EmbedBuilder().WithSmallTitle(
+        var title = string.Format(Messages.UserUnmuted, target.GetTag());
+        var description = string.Format(Messages.DescriptionActionReason, reason);
+        var logResult = _utility.LogActionAsync(
+            data.Settings, channelId, user, title, description, target, CancellationToken);
+        if (!logResult.IsSuccess)
+            return Result.FromError(logResult.Error);
+
+        var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.UserUnmuted, target.GetTag()), target)
             .WithColour(ColorsList.Green).Build();
 
-        if ((!GuildSettings.PublicFeedbackChannel.Get(cfg).Empty()
-             && GuildSettings.PublicFeedbackChannel.Get(cfg) != channelId.Value)
-            || (!GuildSettings.PrivateFeedbackChannel.Get(cfg).Empty()
-                && GuildSettings.PrivateFeedbackChannel.Get(cfg) != channelId.Value)) {
-            var logEmbed = new EmbedBuilder().WithSmallTitle(
-                    string.Format(Messages.UserUnmuted, target.GetTag()), target)
-                .WithDescription(string.Format(Messages.DescriptionActionReason, reason))
-                .WithActionFooter(user)
-                .WithCurrentTimestamp()
-                .WithColour(ColorsList.Green)
-                .Build();
-
-            if (!logEmbed.IsDefined(out var logBuilt))
-                return Result.FromError(logEmbed);
-
-            var builtArray = new[] { logBuilt };
-
-            // Not awaiting to reduce response time
-            if (GuildSettings.PublicFeedbackChannel.Get(cfg) != channelId.Value)
-                _ = _channelApi.CreateMessageAsync(
-                    GuildSettings.PublicFeedbackChannel.Get(cfg), embeds: builtArray,
-                    ct: CancellationToken);
-            if (GuildSettings.PrivateFeedbackChannel.Get(cfg) != GuildSettings.PublicFeedbackChannel.Get(cfg)
-                && GuildSettings.PrivateFeedbackChannel.Get(cfg) != channelId.Value)
-                _ = _channelApi.CreateMessageAsync(
-                    GuildSettings.PrivateFeedbackChannel.Get(cfg), embeds: builtArray,
-                    ct: CancellationToken);
-        }
-
-        return await _feedbackService.SendContextualEmbedResultAsync(responseEmbed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
     }
 }

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -91,15 +91,16 @@ public class MuteCommandGroup : CommandGroup {
             return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
         }
 
-        return await MuteUserAsync(target, reason, duration, guildId.Value, data, channelId.Value, user, currentUser);
+        return await MuteUserAsync(
+            target, reason, duration, guildId.Value, data, channelId.Value, user, currentUser, CancellationToken);
     }
 
     private async Task<Result> MuteUserAsync(
-        IUser target, string reason, TimeSpan duration, Snowflake guildId, GuildData data, Snowflake channelId,
-        IUser user,   IUser  currentUser) {
+        IUser target, string reason,      TimeSpan duration, Snowflake guildId, GuildData data, Snowflake channelId,
+        IUser user,   IUser  currentUser, CancellationToken ct = default) {
         var interactionResult
             = await _utility.CheckInteractionsAsync(
-                guildId, user.ID, target.ID, "Mute", CancellationToken);
+                guildId, user.ID, target.ID, "Mute", ct);
         if (!interactionResult.IsSuccess)
             return Result.FromError(interactionResult);
 
@@ -107,13 +108,13 @@ public class MuteCommandGroup : CommandGroup {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
                 .WithColour(ColorsList.Red).Build();
 
-            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, CancellationToken);
+            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
         var until = DateTimeOffset.UtcNow.Add(duration); // >:)
         var muteResult = await _guildApi.ModifyGuildMemberAsync(
             guildId, target.ID, reason: $"({user.GetTag()}) {reason}".EncodeHeader(),
-            communicationDisabledUntil: until, ct: CancellationToken);
+            communicationDisabledUntil: until, ct: ct);
         if (!muteResult.IsSuccess)
             return Result.FromError(muteResult.Error);
 
@@ -124,7 +125,7 @@ public class MuteCommandGroup : CommandGroup {
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until))).ToString();
 
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, CancellationToken);
+            data.Settings, channelId, user, title, description, target, ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
@@ -132,7 +133,7 @@ public class MuteCommandGroup : CommandGroup {
                 string.Format(Messages.UserMuted, target.GetTag()), target)
             .WithColour(ColorsList.Green).Build();
 
-        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, ct);
     }
 
     /// <summary>
@@ -185,15 +186,16 @@ public class MuteCommandGroup : CommandGroup {
             return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
         }
 
-        return await UnmuteUserAsync(target, reason, guildId.Value, data, channelId.Value, user, currentUser);
+        return await UnmuteUserAsync(
+            target, reason, guildId.Value, data, channelId.Value, user, currentUser, CancellationToken);
     }
 
     private async Task<Result> UnmuteUserAsync(
-        IUser target, string reason, Snowflake guildId, GuildData data, Snowflake channelId, IUser user,
-        IUser currentUser) {
+        IUser target,      string            reason, Snowflake guildId, GuildData data, Snowflake channelId, IUser user,
+        IUser currentUser, CancellationToken ct = default) {
         var interactionResult
             = await _utility.CheckInteractionsAsync(
-                guildId, user.ID, target.ID, "Unmute", CancellationToken);
+                guildId, user.ID, target.ID, "Unmute", ct);
         if (!interactionResult.IsSuccess)
             return Result.FromError(interactionResult);
 
@@ -201,19 +203,19 @@ public class MuteCommandGroup : CommandGroup {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(interactionResult.Entity, currentUser)
                 .WithColour(ColorsList.Red).Build();
 
-            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, CancellationToken);
+            return await _feedbackService.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
         var unmuteResult = await _guildApi.ModifyGuildMemberAsync(
             guildId, target.ID, $"({user.GetTag()}) {reason}".EncodeHeader(),
-            communicationDisabledUntil: null, ct: CancellationToken);
+            communicationDisabledUntil: null, ct: ct);
         if (!unmuteResult.IsSuccess)
             return Result.FromError(unmuteResult.Error);
 
         var title = string.Format(Messages.UserUnmuted, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, CancellationToken);
+            data.Settings, channelId, user, title, description, target, ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
@@ -221,6 +223,6 @@ public class MuteCommandGroup : CommandGroup {
                 string.Format(Messages.UserUnmuted, target.GetTag()), target)
             .WithColour(ColorsList.Green).Build();
 
-        return await _feedbackService.SendContextualEmbedResultAsync(embed, CancellationToken);
+        return await _feedbackService.SendContextualEmbedResultAsync(embed, ct);
     }
 }

--- a/src/InteractionResponders.cs
+++ b/src/InteractionResponders.cs
@@ -31,6 +31,6 @@ public class InteractionResponders : InteractionGroup {
         var idArray = state.Split(':');
         return (Result)await _feedbackService.SendContextualAsync(
             $"https://discord.com/events/{idArray[0]}/{idArray[1]}",
-            options: new FeedbackMessageOptions(MessageFlags: MessageFlags.Ephemeral));
+            options: new FeedbackMessageOptions(MessageFlags: MessageFlags.Ephemeral), ct: CancellationToken);
     }
 }

--- a/src/Services/GuildUpdateService.cs
+++ b/src/Services/GuildUpdateService.cs
@@ -302,11 +302,11 @@ public class GuildUpdateService : BackgroundService {
         IGuildScheduledEvent scheduledEvent, string eventDescription) {
         Result<string> embedDescription;
         if (!scheduledEvent.EntityMetadata.AsOptional().IsDefined(out var metadata))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.EntityMetadata)));
         if (!scheduledEvent.ScheduledEndTime.AsOptional().IsDefined(out var endTime))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime)));
         if (!metadata.Location.IsDefined(out var location))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(metadata.Location)));
 
         embedDescription = $"{eventDescription}\n\n{Markdown.BlockQuote(
             string.Format(
@@ -398,7 +398,7 @@ public class GuildUpdateService : BackgroundService {
     private static Result<string> GetLocalEventStartedEmbedDescription(IGuildScheduledEvent scheduledEvent) {
         Result<string> embedDescription;
         if (!scheduledEvent.ChannelID.AsOptional().IsDefined(out var channelId))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ChannelID)));
 
         embedDescription = string.Format(
             Messages.DescriptionLocalEventStarted,
@@ -410,11 +410,11 @@ public class GuildUpdateService : BackgroundService {
     private static Result<string> GetExternalEventStartedEmbedDescription(IGuildScheduledEvent scheduledEvent) {
         Result<string> embedDescription;
         if (!scheduledEvent.EntityMetadata.AsOptional().IsDefined(out var metadata))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.EntityMetadata)));
         if (!scheduledEvent.ScheduledEndTime.AsOptional().IsDefined(out var endTime))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime)));
         if (!metadata.Location.IsDefined(out var location))
-            return embedDescription;
+            return Result<string>.FromError(new ArgumentNullError(nameof(metadata.Location)));
 
         embedDescription = string.Format(
             Messages.DescriptionExternalEventStarted,


### PR DESCRIPTION
This PR uses a new feature of the InspectCode action: extensions. By adding the `Cognitive Complexity` extension, InspectCode can provide warnings and force the contributors to follow standards regarding complex methods. This functionality was previously provided by CodeFactor, but it is no longer used. Here's the full changelog of this PR:
- Allowed Actions to run on push for any branch, not just `master`;
- Added `Cognitive Complexity` plugin for InspectCode;
- Significantly reduced complexity of KickCommandGroup, MuteCommandGroup and GuildUpdateService