### PR TITLE
Add Color and Public parameters to LogActionAsync

### DIFF
--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -153,7 +153,7 @@ public class BanCommandGroup : CommandGroup {
             .WithColour(ColorsList.Green).Build();
 
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, ct);
+            data.Settings, channelId, user, title, description, target, ColorsList.Red, ct: ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
@@ -227,7 +227,8 @@ public class BanCommandGroup : CommandGroup {
 
         var title = string.Format(Messages.UserUnbanned, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
-        var logResult = _utility.LogActionAsync(data.Settings, channelId, user, title, description, target, ct);
+        var logResult = _utility.LogActionAsync(
+            data.Settings, channelId, user, title, description, target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Commands/ClearCommandGroup.cs
+++ b/src/Commands/ClearCommandGroup.cs
@@ -103,7 +103,7 @@ public class ClearCommandGroup : CommandGroup {
             return Result.FromError(deleteResult.Error);
 
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, currentUser, ct);
+            data.Settings, channelId, user, title, description, currentUser, ColorsList.Red, false, ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -133,7 +133,7 @@ public class KickCommandGroup : CommandGroup {
         var title = string.Format(Messages.UserKicked, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, ct);
+            data.Settings, channelId, user, title, description, target, ColorsList.Red, ct: ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -125,7 +125,7 @@ public class MuteCommandGroup : CommandGroup {
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until))).ToString();
 
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, ct);
+            data.Settings, channelId, user, title, description, target, ColorsList.Red, ct: ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 
@@ -215,7 +215,7 @@ public class MuteCommandGroup : CommandGroup {
         var title = string.Format(Messages.UserUnmuted, target.GetTag());
         var description = string.Format(Messages.DescriptionActionReason, reason);
         var logResult = _utility.LogActionAsync(
-            data.Settings, channelId, user, title, description, target, ct);
+            data.Settings, channelId, user, title, description, target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)
             return Result.FromError(logResult.Error);
 

--- a/src/Services/UtilityService.cs
+++ b/src/Services/UtilityService.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Text;
 using System.Text.Json.Nodes;
 using Boyfriend.Data;
@@ -158,11 +159,13 @@ public class UtilityService : IHostedService {
     /// <param name="title">The title for the embed.</param>
     /// <param name="description">The description of the embed.</param>
     /// <param name="avatar">The user whose avatar will be displayed next to the <paramref name="title" /> of the embed.</param>
+    /// <param name="color">The color of the embed.</param>
+    /// <param name="isPublic">Whether or not the embed should be sent in <see cref="GuildSettings.PublicFeedbackChannel"/></param>
     /// <param name="ct">The cancellation token for this operation.</param>
-    /// <returns></returns>
+    /// <returns>A result which has succeeded.</returns>
     public Result LogActionAsync(
-        JsonNode          cfg, Snowflake channelId, IUser user, string title, string description, IUser avatar,
-        CancellationToken ct = default) {
+        JsonNode cfg,   Snowflake channelId,       IUser user, string title, string description, IUser avatar,
+        Color    color, bool      isPublic = true, CancellationToken ct = default) {
         var publicChannel = GuildSettings.PublicFeedbackChannel.Get(cfg);
         var privateChannel = GuildSettings.PrivateFeedbackChannel.Get(cfg);
         if (GuildSettings.PublicFeedbackChannel.Get(cfg).EmptyOrEqualTo(channelId)
@@ -173,7 +176,7 @@ public class UtilityService : IHostedService {
             .WithDescription(description)
             .WithActionFooter(user)
             .WithCurrentTimestamp()
-            .WithColour(ColorsList.Green)
+            .WithColour(color)
             .Build();
 
         if (!logEmbed.IsDefined(out var logBuilt))
@@ -182,7 +185,7 @@ public class UtilityService : IHostedService {
         var builtArray = new[] { logBuilt };
 
         // Not awaiting to reduce response time
-        if (publicChannel != channelId.Value)
+        if (isPublic && publicChannel != channelId.Value)
             _ = _channelApi.CreateMessageAsync(
                 publicChannel, embeds: builtArray,
                 ct: ct);


### PR DESCRIPTION
This PR adds the `color` and `isPublic` parameters to `UtilityService#LogActionAsync`. Previously, all embeds would be sent in both public and private feedback channels with the green embed color. It is now possible to change these fields, allowing for usage of the red color in punishment commands and allowing to hide the result of `/clear` from public eyes.