### PR TITLE
Do not wrap result errors when returning them

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -50,8 +50,7 @@ public class AboutCommandGroup : CommandGroup {
     [UsedImplicitly]
     public async Task<Result> ExecuteAboutAsync() {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -71,8 +71,7 @@ public class BanCommandGroup : CommandGroup {
         [Description("Ban reason")]   string    reason,
         [Description("Ban duration")] TimeSpan? duration = null) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
         // The current user's avatar is used when sending error messages
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))
@@ -186,8 +185,7 @@ public class BanCommandGroup : CommandGroup {
         [Description("User to unban")] IUser  target,
         [Description("Unban reason")]  string reason) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
         // The current user's avatar is used when sending error messages
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))

--- a/src/Commands/ClearCommandGroup.cs
+++ b/src/Commands/ClearCommandGroup.cs
@@ -61,8 +61,7 @@ public class ClearCommandGroup : CommandGroup {
         [Description("Number of messages to remove (2-100)")] [MinValue(2)] [MaxValue(100)]
         int amount) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var messagesResult = await _channelApi.GetChannelMessagesAsync(
             channelId, limit: amount + 1, ct: CancellationToken);

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -66,8 +66,7 @@ public class KickCommandGroup : CommandGroup {
         [Description("Member to kick")] IUser  target,
         [Description("Kick reason")]    string reason) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
         // The current user's avatar is used when sending error messages
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -68,8 +68,7 @@ public class MuteCommandGroup : CommandGroup {
         [Description("Mute reason")]    string   reason,
         [Description("Mute duration")]  TimeSpan duration) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         // The current user's avatar is used when sending error messages
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
@@ -162,8 +161,7 @@ public class MuteCommandGroup : CommandGroup {
         [Description("Member to unmute")] IUser  target,
         [Description("Unmute reason")]    string reason) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         // The current user's avatar is used when sending error messages
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);

--- a/src/Commands/PingCommandGroup.cs
+++ b/src/Commands/PingCommandGroup.cs
@@ -53,8 +53,7 @@ public class PingCommandGroup : CommandGroup {
     [UsedImplicitly]
     public async Task<Result> ExecutePingAsync() {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out _))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -52,8 +52,7 @@ public class RemindCommandGroup : CommandGroup {
         TimeSpan @in,
         [Description("Reminder message")] string message) {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var userId))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var userResult = await _userApi.GetUserAsync(userId, CancellationToken);
         if (!userResult.IsDefined(out var user))

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -71,8 +71,7 @@ public class SettingsCommandGroup : CommandGroup {
     public async Task<Result> ExecuteSettingsListAsync(
         [Description("Settings list page")] int page) {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))
@@ -142,8 +141,7 @@ public class SettingsCommandGroup : CommandGroup {
         string setting,
         [Description("Setting value")] string value) {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))
-            return Result.FromError(
-                new ArgumentNullError(nameof(_context), "Unable to retrieve necessary IDs from command context"));
+            return new ArgumentInvalidError(nameof(_context), "Unable to retrieve necessary IDs from command context");
 
         var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
         if (!currentUserResult.IsDefined(out var currentUser))

--- a/src/Data/Options/BoolOption.cs
+++ b/src/Data/Options/BoolOption.cs
@@ -12,7 +12,7 @@ public class BoolOption : Option<bool> {
 
     public override Result Set(JsonNode settings, string from) {
         if (!TryParseBool(from, out var value))
-            return Result.FromError(new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue));
+            return new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue);
 
         settings[Name] = value;
         return Result.FromSuccess();

--- a/src/Data/Options/LanguageOption.cs
+++ b/src/Data/Options/LanguageOption.cs
@@ -29,6 +29,6 @@ public class LanguageOption : Option<CultureInfo> {
     public override Result Set(JsonNode settings, string from) {
         return CultureInfoCache.ContainsKey(from.ToLowerInvariant())
             ? base.Set(settings, from.ToLowerInvariant())
-            : Result.FromError(new ArgumentInvalidError(nameof(from), Messages.LanguageNotSupported));
+            : new ArgumentInvalidError(nameof(from), Messages.LanguageNotSupported);
     }
 }

--- a/src/Data/Options/SnowflakeOption.cs
+++ b/src/Data/Options/SnowflakeOption.cs
@@ -20,7 +20,7 @@ public partial class SnowflakeOption : Option<Snowflake> {
 
     public override Result Set(JsonNode settings, string from) {
         if (!ulong.TryParse(NonNumbers().Replace(from, ""), out var parsed))
-            return Result.FromError(new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue));
+            return new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue);
 
         settings[Name] = parsed;
         return Result.FromSuccess();

--- a/src/Data/Options/TimeSpanOption.cs
+++ b/src/Data/Options/TimeSpanOption.cs
@@ -16,7 +16,7 @@ public class TimeSpanOption : Option<TimeSpan> {
 
     public override Result Set(JsonNode settings, string from) {
         if (!ParseTimeSpan(from).IsDefined(out var span))
-            return Result.FromError(new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue));
+            return new ArgumentInvalidError(nameof(from), Messages.InvalidSettingValue);
 
         settings[Name] = span.ToString();
         return Result.FromSuccess();

--- a/src/InteractionResponders.cs
+++ b/src/InteractionResponders.cs
@@ -26,7 +26,7 @@ public class InteractionResponders : InteractionGroup {
     [Button("scheduled-event-details")]
     [UsedImplicitly]
     public async Task<Result> OnStatefulButtonClicked(string? state = null) {
-        if (state is null) return Result.FromError(new ArgumentNullError(nameof(state)));
+        if (state is null) return new ArgumentNullError(nameof(state));
 
         var idArray = state.Split(':');
         return (Result)await _feedbackService.SendContextualAsync(

--- a/src/Responders/GuildMemberJoinedResponder.cs
+++ b/src/Responders/GuildMemberJoinedResponder.cs
@@ -29,7 +29,7 @@ public class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd> {
 
     public async Task<Result> RespondAsync(IGuildMemberAdd gatewayEvent, CancellationToken ct = default) {
         if (!gatewayEvent.User.IsDefined(out var user))
-            return Result.FromError(new ArgumentNullError(nameof(gatewayEvent.User)));
+            return new ArgumentNullError(nameof(gatewayEvent.User));
         var data = await _dataService.GetData(gatewayEvent.GuildID, ct);
         var cfg = data.Settings;
         if (GuildSettings.PublicFeedbackChannel.Get(cfg).Empty()

--- a/src/Responders/MessageEditedResponder.cs
+++ b/src/Responders/MessageEditedResponder.cs
@@ -45,9 +45,9 @@ public class MessageEditedResponder : IResponder<IMessageUpdate> {
             return Result.FromSuccess(); // The message wasn't actually edited
 
         if (!gatewayEvent.ChannelID.IsDefined(out var channelId))
-            return Result.FromError(new ArgumentNullError(nameof(gatewayEvent.ChannelID)));
+            return new ArgumentNullError(nameof(gatewayEvent.ChannelID));
         if (!gatewayEvent.ID.IsDefined(out var messageId))
-            return Result.FromError(new ArgumentNullError(nameof(gatewayEvent.ID)));
+            return new ArgumentNullError(nameof(gatewayEvent.ID));
 
         var cacheKey = new KeyHelpers.MessageCacheKey(channelId, messageId);
         var messageResult = await _cacheService.TryGetValueAsync<IMessage>(

--- a/src/Services/GuildUpdateService.cs
+++ b/src/Services/GuildUpdateService.cs
@@ -163,7 +163,7 @@ public partial class GuildUpdateService : BackgroundService {
                     await SendScheduledEventCreatedMessage(scheduledEvent, data.Settings, ct),
                 GuildScheduledEventStatus.Active or GuildScheduledEventStatus.Completed =>
                     await SendScheduledEventUpdatedMessage(scheduledEvent, data, ct),
-                _ => Result.FromError(new ArgumentOutOfRangeError(nameof(scheduledEvent.Status)))
+                _ => new ArgumentOutOfRangeError(nameof(scheduledEvent.Status))
             };
 
             if (!statusChangedResponseResult.IsSuccess)
@@ -295,7 +295,7 @@ public partial class GuildUpdateService : BackgroundService {
     private async Task<Result> SendScheduledEventCreatedMessage(
         IGuildScheduledEvent scheduledEvent, JsonNode settings, CancellationToken ct = default) {
         if (!scheduledEvent.Creator.IsDefined(out var creator))
-            return Result.FromError(new ArgumentNullError(nameof(scheduledEvent.Creator)));
+            return new ArgumentNullError(nameof(scheduledEvent.Creator));
 
         Result<string> embedDescriptionResult;
         var eventDescription = scheduledEvent.Description is { HasValue: true, Value: not null }
@@ -306,7 +306,7 @@ public partial class GuildUpdateService : BackgroundService {
                 GetLocalEventCreatedEmbedDescription(scheduledEvent, eventDescription),
             GuildScheduledEventEntityType.External => GetExternalScheduledEventCreatedEmbedDescription(
                 scheduledEvent, eventDescription),
-            _ => Result<string>.FromError(new ArgumentOutOfRangeError(nameof(scheduledEvent.EntityType)))
+            _ => new ArgumentOutOfRangeError(nameof(scheduledEvent.EntityType))
         };
 
         if (!embedDescriptionResult.IsDefined(out var embedDescription))
@@ -343,11 +343,11 @@ public partial class GuildUpdateService : BackgroundService {
         IGuildScheduledEvent scheduledEvent, string eventDescription) {
         Result<string> embedDescription;
         if (!scheduledEvent.EntityMetadata.AsOptional().IsDefined(out var metadata))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.EntityMetadata)));
+            return new ArgumentNullError(nameof(scheduledEvent.EntityMetadata));
         if (!scheduledEvent.ScheduledEndTime.AsOptional().IsDefined(out var endTime))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime)));
+            return new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime));
         if (!metadata.Location.IsDefined(out var location))
-            return Result<string>.FromError(new ArgumentNullError(nameof(metadata.Location)));
+            return new ArgumentNullError(nameof(metadata.Location));
 
         embedDescription = $"{eventDescription}\n\n{Markdown.BlockQuote(
             string.Format(
@@ -362,7 +362,7 @@ public partial class GuildUpdateService : BackgroundService {
     private static Result<string> GetLocalEventCreatedEmbedDescription(
         IGuildScheduledEvent scheduledEvent, string eventDescription) {
         if (!scheduledEvent.ChannelID.AsOptional().IsDefined(out var channelId))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ChannelID)));
+            return new ArgumentNullError(nameof(scheduledEvent.ChannelID));
 
         return $"{eventDescription}\n\n{Markdown.BlockQuote(
             string.Format(
@@ -390,7 +390,7 @@ public partial class GuildUpdateService : BackgroundService {
                 GuildScheduledEventEntityType.StageInstance or GuildScheduledEventEntityType.Voice =>
                     GetLocalEventStartedEmbedDescription(scheduledEvent),
                 GuildScheduledEventEntityType.External => GetExternalEventStartedEmbedDescription(scheduledEvent),
-                _ => Result<string>.FromError(new ArgumentOutOfRangeError(nameof(scheduledEvent.EntityType)))
+                _ => new ArgumentOutOfRangeError(nameof(scheduledEvent.EntityType))
             };
 
             var contentResult = await _utility.GetEventNotificationMentions(
@@ -414,7 +414,7 @@ public partial class GuildUpdateService : BackgroundService {
         }
 
         if (scheduledEvent.Status != GuildScheduledEventStatus.Completed)
-            return Result.FromError(new ArgumentOutOfRangeError(nameof(scheduledEvent.Status)));
+            return new ArgumentOutOfRangeError(nameof(scheduledEvent.Status));
         data.ScheduledEvents.Remove(scheduledEvent.ID.Value);
 
         var completedEmbed = new EmbedBuilder().WithTitle(string.Format(Messages.EventCompleted, scheduledEvent.Name))
@@ -439,7 +439,7 @@ public partial class GuildUpdateService : BackgroundService {
     private static Result<string> GetLocalEventStartedEmbedDescription(IGuildScheduledEvent scheduledEvent) {
         Result<string> embedDescription;
         if (!scheduledEvent.ChannelID.AsOptional().IsDefined(out var channelId))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ChannelID)));
+            return new ArgumentNullError(nameof(scheduledEvent.ChannelID));
 
         embedDescription = string.Format(
             Messages.DescriptionLocalEventStarted,
@@ -451,11 +451,11 @@ public partial class GuildUpdateService : BackgroundService {
     private static Result<string> GetExternalEventStartedEmbedDescription(IGuildScheduledEvent scheduledEvent) {
         Result<string> embedDescription;
         if (!scheduledEvent.EntityMetadata.AsOptional().IsDefined(out var metadata))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.EntityMetadata)));
+            return new ArgumentNullError(nameof(scheduledEvent.EntityMetadata));
         if (!scheduledEvent.ScheduledEndTime.AsOptional().IsDefined(out var endTime))
-            return Result<string>.FromError(new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime)));
+            return new ArgumentNullError(nameof(scheduledEvent.ScheduledEndTime));
         if (!metadata.Location.IsDefined(out var location))
-            return Result<string>.FromError(new ArgumentNullError(nameof(metadata.Location)));
+            return new ArgumentNullError(nameof(metadata.Location));
 
         embedDescription = string.Format(
             Messages.DescriptionExternalEventStarted,

--- a/src/Services/UtilityService.cs
+++ b/src/Services/UtilityService.cs
@@ -92,9 +92,9 @@ public class UtilityService : IHostedService {
         string action, IGuild guild, IReadOnlyList<IRole> roles, IGuildMember targetMember, IGuildMember currentMember,
         IGuildMember interacter) {
         if (!targetMember.User.IsDefined(out var targetUser))
-            return Result<string?>.FromError(new ArgumentNullError(nameof(targetMember.User)));
+            return new ArgumentNullError(nameof(targetMember.User));
         if (!interacter.User.IsDefined(out var interacterUser))
-            return Result<string?>.FromError(new ArgumentNullError(nameof(interacter.User)));
+            return new ArgumentNullError(nameof(interacter.User));
 
         if (currentMember.User == targetMember.User)
             return Result<string?>.FromSuccess($"UserCannot{action}Bot".Localized());


### PR DESCRIPTION
This PR removes the wrapping of in-house created result errors with `Result.FromError` (I did not know this was possible until today, lol), which reduces code verbosity and makes it easier to read, and replaces `ArgumentNullError` with `ArgumentInvalidError` when retrieving IDs from a command context, which, in my opinion, is more correct.
