### PR TITLE
Add logging to file

### DIFF
--- a/Boyfriend.csproj
+++ b/Boyfriend.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="Remora.Discord.Extensions" Version="5.3.2"/>
         <PackageReference Include="Remora.Discord.Hosting" Version="6.0.7"/>
         <PackageReference Include="Remora.Discord.Interactivity" Version="4.5.1"/>
+        <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0"/>
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Update="locale\Messages.resx">

--- a/src/Boyfriend.cs
+++ b/src/Boyfriend.cs
@@ -95,6 +95,8 @@ public class Boyfriend {
                 }
             ).ConfigureLogging(
                 c => c.AddConsole()
+                    .AddFile("Logs/Boyfriend-{Date}.log",
+                             outputTemplate: "{Timestamp:o} [{Level:u4}] {Message} {NewLine}{Exception}")
                     .AddFilter("System.Net.Http.HttpClient.*.LogicalHandler", LogLevel.Warning)
                     .AddFilter("System.Net.Http.HttpClient.*.ClientHandler", LogLevel.Warning)
             );

--- a/src/Boyfriend.cs
+++ b/src/Boyfriend.cs
@@ -18,6 +18,7 @@ using Remora.Discord.Gateway.Extensions;
 using Remora.Discord.Hosting.Extensions;
 using Remora.Discord.Interactivity.Extensions;
 using Remora.Rest.Core;
+using Serilog.Extensions.Logging;
 
 namespace Boyfriend;
 
@@ -99,6 +100,8 @@ public class Boyfriend {
                              outputTemplate: "{Timestamp:o} [{Level:u4}] {Message} {NewLine}{Exception}")
                     .AddFilter("System.Net.Http.HttpClient.*.LogicalHandler", LogLevel.Warning)
                     .AddFilter("System.Net.Http.HttpClient.*.ClientHandler", LogLevel.Warning)
+                    .AddFilter<SerilogLoggerProvider>("System.Net.Http.HttpClient.*.LogicalHandler", LogLevel.Warning)
+                    .AddFilter<SerilogLoggerProvider>("System.Net.Http.HttpClient.*.ClientHandler", LogLevel.Warning)
             );
     }
 }


### PR DESCRIPTION
This PR adds the package `Serilog.Extensions.Logging.File` to add logging to file. I decided this was necessary after the bot unexpectedly went down in a tmux session, leaving no traces behind.

![image](https://github.com/TeamOctolings/Boyfriend/assets/61277953/b6ff9e69-b370-4844-b552-db4a39933f62)
