### PR TITLE
Fix roles not returning on rejoin if welcome messages were disabled

### DIFF
--- a/src/Responders/GuildMemberJoinedResponder.cs
+++ b/src/Responders/GuildMemberJoinedResponder.cs
@@ -38,11 +38,6 @@ public class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
 
         var data = await _guildData.GetData(gatewayEvent.GuildID, ct);
         var cfg = data.Settings;
-        if (GuildSettings.PublicFeedbackChannel.Get(cfg).Empty()
-            || GuildSettings.WelcomeMessage.Get(cfg) is "off" or "disable" or "disabled")
-        {
-            return Result.FromSuccess();
-        }
 
         if (GuildSettings.ReturnRolesOnRejoin.Get(cfg))
         {
@@ -53,6 +48,12 @@ public class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
             {
                 return Result.FromError(result.Error);
             }
+        }
+
+        if (GuildSettings.PublicFeedbackChannel.Get(cfg).Empty()
+            || GuildSettings.WelcomeMessage.Get(cfg) is "off" or "disable" or "disabled")
+        {
+            return Result.FromSuccess();
         }
 
         Messages.Culture = GuildSettings.Language.Get(cfg);


### PR DESCRIPTION
This PR fixes an issue where, if the `PublicFeedbackChannel` wasn't set or the welcome message was disabled, `GuildMemberJoinedResponder` would `return` early, causing roles to not be granted back if `ReturnRolesOnRejoin` was enabled, by moving the `if return` after the code that grants back roles