### PR TITLE
Scheduled event update bugfixes

### DIFF
--- a/src/Data/ScheduledEventData.cs
+++ b/src/Data/ScheduledEventData.cs
@@ -8,12 +8,12 @@ namespace Boyfriend.Data;
 /// <remarks>This information is stored on disk as a JSON file.</remarks>
 public sealed class ScheduledEventData
 {
-    public ScheduledEventData(GuildScheduledEventStatus status)
+    public ScheduledEventData(GuildScheduledEventStatus? status)
     {
         Status = status;
     }
 
     public bool EarlyNotificationSent { get; set; }
     public DateTimeOffset? ActualStartTime { get; set; }
-    public GuildScheduledEventStatus Status { get; set; }
+    public GuildScheduledEventStatus? Status { get; set; }
 }

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -79,9 +79,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
                 continue;
             }
 
-            storedEvent.Status = scheduledEvent.Status;
-
-            var statusChangedResponseResult = storedEvent.Status switch
+            var statusChangedResponseResult = scheduledEvent.Status switch
             {
                 GuildScheduledEventStatus.Scheduled =>
                     await SendScheduledEventCreatedMessage(scheduledEvent, data.Settings, ct),
@@ -89,6 +87,11 @@ public sealed class ScheduledEventUpdateService : BackgroundService
                     await SendScheduledEventUpdatedMessage(scheduledEvent, data, ct),
                 _ => new ArgumentOutOfRangeError(nameof(scheduledEvent.Status))
             };
+            if (statusChangedResponseResult.IsSuccess)
+            {
+                storedEvent.Status = scheduledEvent.Status;
+            }
+
             failedResults.AddIfFailed(statusChangedResponseResult);
         }
 

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -68,7 +68,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         {
             if (!data.ScheduledEvents.ContainsKey(scheduledEvent.ID.Value))
             {
-                data.ScheduledEvents.Add(scheduledEvent.ID.Value, new ScheduledEventData(scheduledEvent.Status));
+                data.ScheduledEvents.Add(scheduledEvent.ID.Value, new ScheduledEventData(null));
             }
 
             var storedEvent = data.ScheduledEvents[scheduledEvent.ID.Value];


### PR DESCRIPTION
This PR fixes the following bugs in ScheduledEventUpdateService:
- When a scheduled event is first added into ScheduledEventData, its status update code will be skipped. This results in some messages not being sent to the EventNotificationChannel
- When the status update code returns an unsuccessful Result, the status in ScheduledEventData will still be updated, meaning that the code will not retry.