### PR TITLE
Add /listremind and /delremind

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -582,4 +582,13 @@
     <data name="Previous" xml:space="preserve">
         <value>Previous</value>
     </data>
+  <data name="ReminderList" xml:space="preserve">
+        <value>{0}'s reminders</value>
+    </data>
+  <data name="InvalidReminderIndex" xml:space="preserve">
+        <value>There's no reminder with that index!</value>
+    </data>
+  <data name="ReminderDeleted" xml:space="preserve">
+        <value>Reminder deleted</value>
+    </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -586,7 +586,7 @@
         <value>Напоминания {0}</value>
     </data>
     <data name="InvalidReminderIndex" xml:space="preserve">
-        <value>У тебя нет упоминания с указанным индексом!</value>
+        <value>У тебя нет напоминания с указанным индексом!</value>
     </data>
     <data name="ReminderDeleted" xml:space="preserve">
         <value>Напоминание удалено</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -582,4 +582,13 @@
     <data name="Previous" xml:space="preserve">
         <value>Назад</value>
     </data>
+    <data name="ReminderList" xml:space="preserve">
+        <value>Напоминания {0}</value>
+    </data>
+    <data name="InvalidReminderIndex" xml:space="preserve">
+        <value>У тебя нет упоминания с указанным индексом!</value>
+    </data>
+    <data name="ReminderDeleted" xml:space="preserve">
+        <value>Напоминание удалено</value>
+    </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -582,4 +582,13 @@
     <data name="Previous" xml:space="preserve">
         <value>предыдущее</value>
     </data>
+    <data name="ReminderList" xml:space="preserve">
+        <value>напоминалки {0}</value>
+    </data>
+    <data name="InvalidReminderIndex" xml:space="preserve">
+        <value>у тебя нет напоминалки с этим индексом!</value>
+    </data>
+    <data name="ReminderDeleted" xml:space="preserve">
+        <value>напоминалка стёрта</value>
+    </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -589,6 +589,6 @@
         <value>у тебя нет напоминалки с этим индексом!</value>
     </data>
     <data name="ReminderDeleted" xml:space="preserve">
-        <value>напоминалка стёрта</value>
+        <value>напоминалка уничтожена</value>
     </data>
 </root>

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -73,13 +73,14 @@ public class RemindCommandGroup : CommandGroup
         for (var i = 0; i < data.Reminders.Count; i++)
         {
             var reminder = data.Reminders[i];
-            builder.AppendLine($"[{i}] {Markdown.InlineCode(reminder.Text)} ({Markdown.Timestamp(reminder.At)})");
+            builder.AppendLine(
+                $"- {Markdown.InlineCode(i.ToString())} - {Markdown.InlineCode(reminder.Text)} - {Markdown.Timestamp(reminder.At)}");
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.ReminderList, user.GetTag()), user)
             .WithDescription(builder.ToString())
-            .WithColour(ColorsList.Default)
+            .WithColour(ColorsList.Cyan)
             .Build();
 
         return await _feedback.SendContextualEmbedResultAsync(
@@ -152,7 +153,7 @@ public class RemindCommandGroup : CommandGroup
     [RequireContext(ChannelContext.Guild)]
     [UsedImplicitly]
     public async Task<Result> ExecuteDeleteReminderAsync(
-        int index)
+        [MinValue(0)] int index)
     {
         if (!_context.TryGetContextIDs(out var guildId, out _, out var userId))
         {
@@ -171,7 +172,8 @@ public class RemindCommandGroup : CommandGroup
         return await DeleteReminderAsync(data.GetOrCreateMemberData(userId), index, currentUser, CancellationToken);
     }
 
-    private async Task<Result> DeleteReminderAsync(MemberData data, int index, IUser currentUser, CancellationToken ct)
+    private async Task<Result> DeleteReminderAsync(MemberData data, int index, IUser currentUser,
+        CancellationToken ct)
     {
         if (index >= data.Reminders.Count)
         {

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -977,5 +977,23 @@ namespace Boyfriend {
                 return ResourceManager.GetString("Previous", resourceCulture);
             }
         }
+
+        internal static string ReminderList {
+            get {
+                return ResourceManager.GetString("ReminderList", resourceCulture);
+            }
+        }
+
+        internal static string InvalidReminderIndex {
+            get {
+                return ResourceManager.GetString("InvalidReminderIndex", resourceCulture);
+            }
+        }
+
+        internal static string ReminderDeleted {
+            get {
+                return ResourceManager.GetString("ReminderDeleted", resourceCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR closes #61.

This PR adds the `/listremind` command and the `/delremind` command. The `/delremind` command requires an index to determine which reminder to delete.

cc @mctaylors review embed design and feature experience