### PR TITLE
Fix a crash in scheduled event early notification

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -433,7 +433,7 @@
     <value>You cannot unmute this user!</value>
   </data>
     <data name="EventEarlyNotification" xml:space="preserve">
-    <value>{0}Event {1} will start &lt;t:{2}:R&gt;!</value>
+    <value>Event "{0}" will start {1}!</value>
   </data>
     <data name="SettingsEventEarlyNotificationOffset" xml:space="preserve">
     <value>Early event start notification offset</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -430,7 +430,7 @@
     <value>Я не могу вернуть из мута этого пользователя!</value>
   </data>
     <data name="EventEarlyNotification" xml:space="preserve">
-    <value>{0}Событие {1} начнется &lt;t:{2}:R&gt;!</value>
+    <value>Событие "{0}" начнется {1}!</value>
   </data>
     <data name="SettingsEventEarlyNotificationOffset" xml:space="preserve">
     <value>Офсет отправки преждевременного уведомления о начале события</value>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -433,7 +433,7 @@
     <value>я не могу его раззамутить...</value>
   </data>
     <data name="EventEarlyNotification" xml:space="preserve">
-    <value>{0}движуха {1} начнется &lt;t:{2}:R&gt;!</value>
+    <value>движуха "{0}" начнется {1}!</value>
   </data>
     <data name="SettingsEventEarlyNotificationOffset" xml:space="preserve">
     <value>заранее пнуть в минутах до начала движухи</value>

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -359,7 +359,9 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         }
 
         var earlyResult = new EmbedBuilder()
-            .WithSmallTitle(string.Format(Messages.EventEarlyNotification, scheduledEvent.Name), currentUser)
+            .WithSmallTitle(
+                string.Format(Messages.EventEarlyNotification, scheduledEvent.Name,
+                    Markdown.Timestamp(scheduledEvent.ScheduledStartTime, TimestampStyle.RelativeTime)), currentUser)
             .WithColour(ColorsList.Default)
             .WithCurrentTimestamp()
             .Build();


### PR DESCRIPTION
This PR fixes a fatal crash that occurs when the bot tries to send an early notification for a scheduled event. An exception is thrown by `string#Format` when the argument list provided doesn't match the argument list in the template. This is fixed by correcting the template and the argument list