### PR TITLE
EventEarlyNotification timestamp bugfix and other changes

### DIFF
--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -253,11 +253,11 @@
     <value>оъмъомоъемъъео((((</value>
   </data>
     <data name="EventCancelled" xml:space="preserve">
-    <value>движуха "{0}" отменен!</value>
-  </data>
+        <value>движуха "{0}" отменена!</value>
+    </data>
     <data name="EventCompleted" xml:space="preserve">
-    <value>движуха "{0}" завершен!</value>
-  </data>
+        <value>движуха "{0}" завершена!</value>
+    </data>
     <data name="Ever" xml:space="preserve">
     <value>всегда</value>
   </data>

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -153,7 +153,9 @@ public class RemindCommandGroup : CommandGroup
     [RequireContext(ChannelContext.Guild)]
     [UsedImplicitly]
     public async Task<Result> ExecuteDeleteReminderAsync(
-        [MinValue(0)] int index)
+        [Description("Index of reminder to delete")]
+        [MinValue(0)]
+        int index)
     {
         if (!_context.TryGetContextIDs(out var guildId, out _, out var userId))
         {

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -62,9 +62,9 @@ public class SettingsCommandGroup : CommandGroup
     }
 
     /// <summary>
-    ///     A slash command that lists current per-guild GuildSettings.
+    ///     A slash command that sends a page from the list of current GuildSettings.
     /// </summary>
-    /// <param name="page">The page number.</param>
+    /// <param name="page">The number of the page to send.</param>
     /// <returns>
     ///     A feedback sending result which may or may not have succeeded.
     /// </returns>

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -64,6 +64,7 @@ public class SettingsCommandGroup : CommandGroup
     /// <summary>
     ///     A slash command that lists current per-guild GuildSettings.
     /// </summary>
+    /// <param name="page">The page number.</param>
     /// <returns>
     ///     A feedback sending result which may or may not have succeeded.
     /// </returns>
@@ -75,7 +76,9 @@ public class SettingsCommandGroup : CommandGroup
     [Description("Shows settings list for this server")]
     [UsedImplicitly]
     public async Task<Result> ExecuteSettingsListAsync(
-        [Description("Settings list page")] int page)
+        [Description("Settings list page")]
+        [MinValue(1)]
+        int page)
     {
         if (!_context.TryGetContextIDs(out var guildId, out _, out _))
         {

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -346,7 +346,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         IGuildScheduledEvent scheduledEvent, GuildData data, CancellationToken ct)
     {
         var currentUserResult = await _userApi.GetCurrentUserAsync(ct);
-        if (!currentUserResult.IsDefined(out var currentUser))
+        if (!currentUserResult.IsDefined(out _))
         {
             return Result.FromError(currentUserResult);
         }
@@ -359,11 +359,10 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         }
 
         var earlyResult = new EmbedBuilder()
-            .WithSmallTitle(
+            .WithDescription(
                 string.Format(Messages.EventEarlyNotification, scheduledEvent.Name,
-                    Markdown.Timestamp(scheduledEvent.ScheduledStartTime, TimestampStyle.RelativeTime)), currentUser)
+                    Markdown.Timestamp(scheduledEvent.ScheduledStartTime, TimestampStyle.RelativeTime)))
             .WithColour(ColorsList.Default)
-            .WithCurrentTimestamp()
             .Build();
 
         if (!earlyResult.IsDefined(out var earlyBuilt))

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -19,18 +19,15 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     private readonly IDiscordRestGuildScheduledEventAPI _eventApi;
     private readonly GuildDataService _guildData;
     private readonly ILogger<ScheduledEventUpdateService> _logger;
-    private readonly IDiscordRestUserAPI _userApi;
     private readonly UtilityService _utility;
 
     public ScheduledEventUpdateService(IDiscordRestChannelAPI channelApi, IDiscordRestGuildScheduledEventAPI eventApi,
-        GuildDataService guildData, ILogger<ScheduledEventUpdateService> logger, IDiscordRestUserAPI userApi,
-        UtilityService utility)
+        GuildDataService guildData, ILogger<ScheduledEventUpdateService> logger, UtilityService utility)
     {
         _channelApi = channelApi;
         _eventApi = eventApi;
         _guildData = guildData;
         _logger = logger;
-        _userApi = userApi;
         _utility = utility;
     }
 
@@ -345,12 +342,6 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     private async Task<Result> SendEarlyEventNotificationAsync(
         IGuildScheduledEvent scheduledEvent, GuildData data, CancellationToken ct)
     {
-        var currentUserResult = await _userApi.GetCurrentUserAsync(ct);
-        if (!currentUserResult.IsDefined(out _))
-        {
-            return Result.FromError(currentUserResult);
-        }
-
         var contentResult = await _utility.GetEventNotificationMentions(
             scheduledEvent, data.Settings, ct);
         if (!contentResult.IsDefined(out var content))


### PR DESCRIPTION
This PR fixes EventEarlyNotification timestamp not displaying correctly and also has some other changes:
- Add xmldocs for `/settingslist`'s `page` option in SettingsCommandGroup.cs
- Add option description for `index` for `/delreminder`
- Some corrections of grammatical errors in Messages.tt-ru.resx
- Fix `ArgumentOutOfRangeException` in `/settingslist` that appears if the user uses a negative integer in `page`