### PR TITLE
Add failed embed for /listremind

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -591,4 +591,7 @@
   <data name="ReminderDeleted" xml:space="preserve">
         <value>Reminder deleted</value>
     </data>
+    <data name="NoRemindersFound" xml:space="preserve">
+        <value>You don't have any reminders created!</value>
+    </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -591,4 +591,7 @@
     <data name="ReminderDeleted" xml:space="preserve">
         <value>Напоминание удалено</value>
     </data>
+    <data name="NoRemindersFound" xml:space="preserve">
+        <value>У вас нет созданных напоминаний!</value>
+    </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -591,4 +591,7 @@
     <data name="ReminderDeleted" xml:space="preserve">
         <value>напоминалка уничтожена</value>
     </data>
+    <data name="NoRemindersFound" xml:space="preserve">
+        <value>ты еще не крафтил напоминалки</value>
+    </data>
 </root>

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -77,6 +77,15 @@ public class RemindCommandGroup : CommandGroup
                 $"- {Markdown.InlineCode(i.ToString())} - {Markdown.InlineCode(reminder.Text)} - {Markdown.Timestamp(reminder.At)}");
         }
 
+        if (data.Reminders.Count == 0)
+        {
+            var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.NoRemindersFound, user)
+                .WithColour(ColorsList.Red)
+                .Build();
+
+            return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
+        }
+
         var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.ReminderList, user.GetTag()), user)
             .WithDescription(builder.ToString())

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -61,29 +61,35 @@ public class RemindCommandGroup : CommandGroup
             return Result.FromError(userResult);
         }
 
+        var currentUserResult = await _userApi.GetCurrentUserAsync(CancellationToken);
+        if (!currentUserResult.IsDefined(out var currentUser))
+        {
+            return Result.FromError(currentUserResult);
+        }
+
         var data = await _guildData.GetData(guildId, CancellationToken);
         Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
-        return await ListRemindersAsync(data.GetOrCreateMemberData(userId), user, CancellationToken);
+        return await ListRemindersAsync(data.GetOrCreateMemberData(userId), user, currentUser, CancellationToken);
     }
 
-    private async Task<Result> ListRemindersAsync(MemberData data, IUser user, CancellationToken ct)
+    private async Task<Result> ListRemindersAsync(MemberData data, IUser user, IUser currentUser, CancellationToken ct)
     {
+        if (data.Reminders.Count == 0)
+        {
+            var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.NoRemindersFound, currentUser)
+                .WithColour(ColorsList.Red)
+                .Build();
+
+            return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
+        }
+
         var builder = new StringBuilder();
         for (var i = 0; i < data.Reminders.Count; i++)
         {
             var reminder = data.Reminders[i];
             builder.AppendLine(
                 $"- {Markdown.InlineCode(i.ToString())} - {Markdown.InlineCode(reminder.Text)} - {Markdown.Timestamp(reminder.At)}");
-        }
-
-        if (data.Reminders.Count == 0)
-        {
-            var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.NoRemindersFound, user)
-                .WithColour(ColorsList.Red)
-                .Build();
-
-            return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -995,5 +995,11 @@ namespace Boyfriend {
                 return ResourceManager.GetString("ReminderDeleted", resourceCulture);
             }
         }
+
+        internal static string NoRemindersFound {
+            get {
+                return ResourceManager.GetString("NoRemindersFound", resourceCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
Without this embed, if there are no reminders created by the user, the bot will endlessly think because StringBuilder will be empty and normal embed will not be shown.