### PR TITLE
Add a JSON deserialization constructor for ScheduledEventData

### DIFF
--- a/src/Data/ScheduledEventData.cs
+++ b/src/Data/ScheduledEventData.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Remora.Discord.API.Abstractions.Objects;
 
 namespace Boyfriend.Data;
@@ -8,13 +9,26 @@ namespace Boyfriend.Data;
 /// <remarks>This information is stored on disk as a JSON file.</remarks>
 public sealed class ScheduledEventData
 {
-    public ScheduledEventData(ulong id, string name, GuildScheduledEventStatus status,
-        DateTimeOffset scheduledStartTime)
+    public ScheduledEventData(ulong id, string name, DateTimeOffset scheduledStartTime,
+        GuildScheduledEventStatus status)
     {
         Id = id;
         Name = name;
-        Status = status;
         ScheduledStartTime = scheduledStartTime;
+        Status = status;
+    }
+
+    [JsonConstructor]
+    public ScheduledEventData(ulong id, string name, bool earlyNotificationSent, DateTimeOffset scheduledStartTime,
+        DateTimeOffset? actualStartTime, GuildScheduledEventStatus? status, bool scheduleOnStatusUpdated)
+    {
+        Id = id;
+        Name = name;
+        EarlyNotificationSent = earlyNotificationSent;
+        ScheduledStartTime = scheduledStartTime;
+        ActualStartTime = actualStartTime;
+        Status = status;
+        ScheduleOnStatusUpdated = scheduleOnStatusUpdated;
     }
 
     public ulong Id { get; }

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -55,7 +55,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             if (!data.ScheduledEvents.TryGetValue(schEvent.ID.Value, out var eventData))
             {
                 data.ScheduledEvents.Add(schEvent.ID.Value, new ScheduledEventData(schEvent.ID.Value,
-                    schEvent.Name, schEvent.Status, schEvent.ScheduledStartTime));
+                    schEvent.Name, schEvent.ScheduledStartTime, schEvent.Status));
                 continue;
             }
 

--- a/src/Responders/ScheduledEventCreatedResponder.cs
+++ b/src/Responders/ScheduledEventCreatedResponder.cs
@@ -25,7 +25,7 @@ public class ScheduledEventCreatedResponder : IResponder<IGuildScheduledEventCre
         var data = await _guildData.GetData(gatewayEvent.GuildID, ct);
         data.ScheduledEvents.Add(gatewayEvent.ID.Value,
             new ScheduledEventData(gatewayEvent.ID.Value,
-                gatewayEvent.Name, gatewayEvent.Status, gatewayEvent.ScheduledStartTime));
+                gatewayEvent.Name, gatewayEvent.ScheduledStartTime, gatewayEvent.Status));
 
         return Result.FromSuccess();
     }


### PR DESCRIPTION
This PR fixes an exception that would occur when deserialization of ScheduledEventData would be attempted. The exception is fixed by providing a constructor containing all properties and adding the `[JsonConstructor]` attribute.